### PR TITLE
fix(aliases): make eza fall back to ls and stop leaking no_aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zwc
 ._zinit/
+tests/_output/

--- a/.zunit.yml
+++ b/.zunit.yml
@@ -1,0 +1,8 @@
+tap: false
+directories:
+  tests: tests
+  output: tests/_output
+  support: tests/_support
+time_limit: 0
+fail_fast: false
+allow_risky: false

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -1,0 +1,43 @@
+#!/usr/bin/env zsh
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:
+#
+# Loaded by ZUnit before every test file.
+
+PLUGIN_DIR=${${0:A:h}:h:h}
+PLUGIN=$PLUGIN_DIR/zsh-aliases.plugin.zsh
+
+# Resolved here because the sandboxed $PATH below must not decide which zsh
+# runs the fixtures.
+ZSH_BIN=${commands[zsh]:-/bin/zsh}
+
+# Run a command in a pristine zsh that has sourced the plugin.
+#
+#   plugin_run <bin-dir> <command...>
+#
+# <bin-dir> is prepended to a minimal $PATH so tests can stub out eza/ls.
+#
+# The command is written to a script rather than passed to `zsh -c`, because
+# `zsh -c` parses the whole string up front, before `setopt aliases` has run,
+# and would therefore never expand the aliases under test.
+function plugin_run() {
+    local bindir=$1; shift
+    local script=$bindir/.plugin_run.zsh
+
+    print -lr -- "source ${(q)PLUGIN}" 'setopt aliases' "$*" > $script
+
+    command env -i \
+        HOME=$HOME \
+        TERM=${TERM:-dumb} \
+        GIT_CONFIG_GLOBAL=/dev/null \
+        GIT_CONFIG_SYSTEM=/dev/null \
+        PATH="$bindir:/usr/bin:/bin:/usr/sbin:/sbin" \
+        $ZSH_BIN -f $script
+}
+
+# Create a stub executable that echoes its own name plus its arguments.
+function stub_bin() {
+    local dir=$1 name=$2
+    command mkdir -p -- $dir
+    command printf '#!/bin/sh\necho "%s $*"\n' $name > $dir/$name
+    command chmod +x $dir/$name
+}

--- a/tests/aliases.zunit
+++ b/tests/aliases.zunit
@@ -1,0 +1,161 @@
+#!/usr/bin/env zunit
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:
+#
+# @setup builds two throwaway $PATH entries holding stub `eza`/`ls` binaries,
+# so each test can control which of the two is discoverable.
+#
+# NOTE: ZUnit's `run` re-quotes and evals its arguments, so a `$` that must
+# survive into the inner shell is written as `\$`.
+
+@setup {
+    STUB_DIR=$(command mktemp -d)
+    NO_EZA_DIR=$STUB_DIR/no-eza
+    WITH_EZA_DIR=$STUB_DIR/with-eza
+
+    stub_bin $NO_EZA_DIR ls
+    stub_bin $WITH_EZA_DIR ls
+    stub_bin $WITH_EZA_DIR eza
+}
+
+@teardown {
+    command rm -rf -- $STUB_DIR
+}
+
+@test 'l falls back to ls when eza is absent' {
+    run plugin_run $NO_EZA_DIR 'l'
+    assert $state equals 0
+    assert $output same_as 'ls --color=auto'
+}
+
+@test 'la falls back to ls when eza is absent' {
+    run plugin_run $NO_EZA_DIR 'la'
+    assert $output same_as 'ls --color=auto -a'
+}
+
+@test 'll falls back to ls when eza is absent' {
+    run plugin_run $NO_EZA_DIR 'll'
+    assert $output same_as 'ls --color=auto -l'
+}
+
+@test 'lr falls back to ls when eza is absent' {
+    run plugin_run $NO_EZA_DIR 'lr'
+    assert $output same_as 'ls --color=auto -lR'
+}
+
+@test 'l prefers eza when it is installed' {
+    run plugin_run $WITH_EZA_DIR 'l'
+    assert $output same_as 'eza --color=auto'
+}
+
+@test 'la ll lr prefer eza when it is installed' {
+    run plugin_run $WITH_EZA_DIR 'la; ll; lr'
+    assert "${lines[1]}" same_as 'eza --color=auto -a'
+    assert "${lines[2]}" same_as 'eza --color=auto -l'
+    assert "${lines[3]}" same_as 'eza --color=auto -lR'
+}
+
+@test 'commands[eza] resolves to an absolute path' {
+    # Called directly rather than through `run`, which would expand the `$`.
+    local out=$(plugin_run $WITH_EZA_DIR 'print -r -- ${commands[eza]}')
+    assert "$out" same_as "$WITH_EZA_DIR/eza"
+}
+
+@test 'commands[eza] is empty when eza is not on PATH' {
+    local out=$(plugin_run $NO_EZA_DIR 'print -r -- "[${commands[eza]}]"')
+    assert "$out" same_as '[]'
+}
+
+@test 'listing aliases resolve eza at run time, not at load time' {
+    # eza only appears on $PATH after the plugin has already been sourced.
+    local out=$(plugin_run $NO_EZA_DIR "PATH=$WITH_EZA_DIR:/usr/bin:/bin; l")
+    assert "$out" same_as 'eza --color=auto'
+}
+
+@test 'listing aliases use --color=auto so pipes stay clean' {
+    run plugin_run $NO_EZA_DIR 'alias l la ll lr'
+    assert $output contains '--color=auto'
+    assert $output does_not_contain '--color '
+}
+
+@test 'cfg honours XDG_CONFIG_HOME' {
+    run plugin_run $NO_EZA_DIR 'alias cfg'
+    assert $output contains 'XDG_CONFIG_HOME'
+    assert $output does_not_contain 'XDG_CONFIG_DIR'
+}
+
+@test 'mkcd creates a nested directory and changes into it' {
+    local target=$STUB_DIR/a/b/c
+    local out=$(plugin_run $NO_EZA_DIR "mkcd ${(q)target}; builtin print -r -- \$PWD")
+    assert $? equals 0
+    assert "$out" same_as "${target:A}"
+}
+
+@test 'mkcd handles paths containing spaces' {
+    local target="$STUB_DIR/two words"
+    local out=$(plugin_run $NO_EZA_DIR "mkcd ${(q)target}; builtin print -r -- \$PWD")
+    assert "$out" same_as "${target:A}"
+}
+
+@test 'get-path prints one $path entry per line' {
+    run plugin_run $NO_EZA_DIR 'get-path'
+    assert "${lines[1]}" same_as "$NO_EZA_DIR"
+    assert "${#lines}" equals 5
+}
+
+@test 'scratchpad expands to a dated markdown path without calling mktemp' {
+    # Direct call: ZUnit's `run` would split this on the `;`.
+    local out=$(plugin_run $NO_EZA_DIR 'EDITOR=print; scratchpad')
+    assert "$out" matches '/scratch-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]+\.md$'
+}
+
+@test 'git-repo-website rewrites an SSH remote to an HTTPS URL' {
+    local repo=$STUB_DIR/repo
+    stub_bin $NO_EZA_DIR open
+    command mkdir -p -- $repo
+    # Ignore the user's git config; url.insteadOf rules would rewrite the remote.
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    command git -C $repo init -q
+    command git -C $repo remote add origin 'git@github.com:vladdoster/zsh-aliases.plugin.zsh.git'
+
+    local out=$(plugin_run $NO_EZA_DIR "builtin cd ${(q)repo}; git-repo-website")
+    assert "$out" same_as 'open https://github.com/vladdoster/zsh-aliases.plugin.zsh'
+}
+
+@test 'git-repo-website leaves an HTTPS remote untouched' {
+    local repo=$STUB_DIR/repo-https
+    stub_bin $NO_EZA_DIR open
+    command mkdir -p -- $repo
+    # Ignore the user's git config; url.insteadOf rules would rewrite the remote.
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    command git -C $repo init -q
+    command git -C $repo remote add origin 'https://github.com/vladdoster/zsh-aliases.plugin.zsh.git'
+
+    local out=$(plugin_run $NO_EZA_DIR "builtin cd ${(q)repo}; git-repo-website")
+    assert "$out" same_as 'open https://github.com/vladdoster/zsh-aliases.plugin.zsh'
+}
+
+@test 'every alias is defined after sourcing the plugin' {
+    local -a expected
+    expected=(
+        '+x' '..' '...' '....' '.....' '?' b rmr mk mkcd scratchpad rsync
+        git-repo-website l la ll lr cfg ezc zdd zrld get-path get-sys get-user
+    )
+    local name
+    for name in $expected; do
+        run plugin_run $NO_EZA_DIR "alias -- ${(q)name}"
+        assert $state equals 0
+        assert $output is_not_empty
+    done
+}
+
+@test 'global aliases are defined' {
+    # Names are quoted, otherwise the global aliases expand in the query itself.
+    run plugin_run $NO_EZA_DIR "alias -g -- 'B' 'C' 'D' 'G' 'L' 'P' 'g'"
+    assert $state equals 0
+    assert "${#lines}" equals 7
+}
+
+@test 'sourcing the plugin does not leak no_aliases into the caller' {
+    local out=$($ZSH_BIN -f -c "source ${(q)PLUGIN}; print -r -- \$options[aliases]")
+    assert "$out" same_as 'on'
+}

--- a/zsh-aliases.plugin.zsh
+++ b/zsh-aliases.plugin.zsh
@@ -7,44 +7,58 @@
 0=${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}
 0=${${(M)0:#/*}:-$PWD/$0}
 
-emulate -L zsh
-setopt no_aliases
+# Wrapped in an anonymous function so `emulate -L` / `setopt no_aliases` are
+# restored on return. At the top level of a sourced file they would leak into
+# the interactive shell and disable alias expansion everywhere.
+() {
+    emulate -L zsh
+    setopt no_aliases
 
-alias -- '+x'='command chmod +x'
-alias -- '..'='builtin cd -- ../ && l'
-alias -- '...'='builtin cd -- ../../ && l'
-alias -- '....'='builtin cd -- ../../../ && l'
-alias -- '.....'='builtin cd -- ../../../../ && l'
-alias -- '?'='command which'
-alias b='builtin cd -'
-alias rmr='command rm -rf --'
+    # ${commands} lives in zsh/parameter; without it every ${commands[x]} lookup is
+    # empty and the eza/ls probing below silently picks the fallback forever.
+    zmodload -F zsh/parameter p:commands
 
-alias -g -- B='command brew'
-alias -g -- C='command cat'
-alias -g -- D='command docker'
-alias -g -- G='command grep -R'
-alias -g -- L='command less'
-alias -g -- P='builtin print -P'
-alias -g -- g='command git'
+    alias -- '+x'='command chmod +x'
+    alias -- '..'='builtin cd -- ../ && l'
+    alias -- '...'='builtin cd -- ../../ && l'
+    alias -- '....'='builtin cd -- ../../../ && l'
+    alias -- '.....'='builtin cd -- ../../../../ && l'
+    alias -- '?'='command which'
+    alias b='builtin cd -'
+    alias rmr='command rm -rf --'
 
-alias mk='command make'
-alias mkcd='{ local DIR_NAME=$(cat -) && command mkdir -p -- $DIR_NAME && builtin cd -P -- $DIR_NAME }<<<'
+    alias -g -- B='command brew'
+    alias -g -- C='command cat'
+    alias -g -- D='command docker'
+    alias -g -- G='command grep -R'
+    alias -g -- L='command less'
+    alias -g -- P='builtin print -P'
+    alias -g -- g='command git'
 
-alias scratchpad='${EDITOR:-vim} $(mktemp -t scratch.XXX.md)'
-alias rsync='rsync -azP'
+    alias mk='command make'
+    alias mkcd='() { command mkdir -p -- "$1" && builtin cd -P -- "$1" }'
 
-alias -- git-repo-website='open $(git remote get-url origin)'
+    # `mktemp -t` means different things on BSD and GNU, and neither accepts a
+    # `.md` suffix reliably; ${(%):-%D} is prompt expansion, so no subprocess.
+    alias scratchpad='${EDITOR:-vim} ${TMPDIR:-/tmp}/scratch-${(%):-%D}-$RANDOM.md'
+    alias rsync='command rsync -azP'
 
-alias -- l='${commands[eza]:-ls} --color'
-alias -- la='${commands[eza]:-ls} -a'
-alias -- ll='${commands[eza]:-ls} -l'
-alias -- lr='${commands[eza]:-ls} -lR'
+    alias -- git-repo-website='() { local u=${$(command git remote get-url origin)%.git}; [[ $u == git@* ]] && u=https://${${u#git@}/://}; ${commands[open]:-xdg-open} $u }'
 
-alias -- cfg='builtin cd ${XDG_CONFIG_DIR:-$HOME/.config/} && l'
-alias -- ezc='${EDITOR:-vim} ${ZDOTDIR:-$HOME}/.zshrc'
-alias -- zdd='builtin cd ${ZDOTDIR:-$HOME/.config/zsh} && l'
-alias -- zrld='builtin exec ${SHELL:-zsh} -l'
+    # ${commands[eza]} is the absolute path to eza, or empty when it is not on
+    # $PATH, so `:-ls` falls back at run time. `--color=auto` is the only spelling
+    # both eza and ls accept, and it keeps escape codes out of pipes.
+    alias -- l='${commands[eza]:-ls} --color=auto'
+    alias -- la='${commands[eza]:-ls} --color=auto -a'
+    alias -- ll='${commands[eza]:-ls} --color=auto -l'
+    alias -- lr='${commands[eza]:-ls} --color=auto -lR'
 
-alias -- get-path='print -l -- ${path[@]}'
-alias -- get-sys='print -l -- OSTYPE=${(qq)OSTYPE} VENDOR=${(qq)VENDOR} MACHTYPE=${(qq)MACHTYPE} CPUTYPE=${(qq)CPUTYPE} hardware=${(qq)$(uname -m)} processor=${(qq)$(uname -p)}'
-alias -- get-user='print -P -- %F{blue}$(whoami)%f @ %F{cyan}$(uname -a)%f'
+    alias -- cfg='builtin cd ${XDG_CONFIG_HOME:-$HOME/.config} && l'
+    alias -- ezc='${EDITOR:-vim} ${ZDOTDIR:-$HOME}/.zshrc'
+    alias -- zdd='builtin cd ${ZDOTDIR:-$HOME/.config/zsh} && l'
+    alias -- zrld='builtin exec ${SHELL:-zsh} -l'
+
+    alias -- get-path='print -l -- $path'
+    alias -- get-sys='print -l -- OSTYPE=${(qq)OSTYPE} VENDOR=${(qq)VENDOR} MACHTYPE=${(qq)MACHTYPE} CPUTYPE=${(qq)CPUTYPE} hardware=${(qq)$(uname -m)} processor=${(qq)$(uname -p)}'
+    alias -- get-user='print -P -- %F{blue}$(whoami)%f @ %F{cyan}$(uname -a)%f'
+}


### PR DESCRIPTION
## Summary

- `l`/`la`/`ll`/`lr` now fall back to `ls` correctly: load `zsh/parameter` so `${commands[eza]}` is populated, and use `--color=auto` (bare `--color` is rejected by BSD `ls` and means `always` on GNU, leaking escapes into pipes)
- stop `setopt no_aliases` leaking into the caller — the body is now an anonymous function so `emulate -L` actually restores options
- `cfg` uses `XDG_CONFIG_HOME`, `mkcd` handles paths with spaces, `scratchpad` drops the non-portable `mktemp -t`, `git-repo-website` works off macOS and rewrites SSH remotes to HTTPS, plus `command`/`$path` cleanups
- add a zunit suite (20 tests) exercising both the eza-present and eza-absent paths against stub binaries